### PR TITLE
fix: degrade go version to 1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/CSU-Apple-Lab/tinyTikTok
 
-go 1.18
+go 1.17
 
 require google.golang.org/protobuf v1.28.1


### PR DESCRIPTION
Changes proposed in this pull request:
  - Degrade go version from 1.18 to 1.17 to enable structcheck

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://juejin.cn/post/7200724414592679995) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have passed make check locally : `make lint`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
