### PR TITLE
chore: sync .github with main

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+Fixes #ISSUSE_ID.
+
+Changes proposed in this pull request:
+-
+
+---
+
+Before committing this PR, I'm sure that I have checked the following options:
+- [ ] My code follows the [code of conduct](https://juejin.cn/post/7200724414592679995) of this project.
+- [ ] I have self-reviewed the commit code.
+- [ ] I have passed make check locally : `make lint`.
+- [ ] I have made corresponding changes to the documentation.
+- [ ] I have added corresponding unit tests for my changes.


### PR DESCRIPTION
Changes proposed in this pull request:
  - Add pull_request_template.md under .github

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://juejin.cn/post/7200724414592679995) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have passed make check locally : `make lint`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
